### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SagenKoder/launcher/security/code-scanning/1](https://github.com/SagenKoder/launcher/security/code-scanning/1)

To fix this problem, you should add a `permissions:` block to the workflow or job definition, restricting the GITHUB_TOKEN permissions to only those needed. In this case, the steps shown only ever need to check out code and upload artifacts; no steps require write access to repository contents, metadata, or pull requests. Therefore, you should assign at least `contents: read` at the workflow level (which applies to all jobs), or at minimum to this `build-linux` job.  

Add the following block immediately after the `name:` line (workflow-level), or as a child of the job spec (job-level). For organizational clarity and reusability, the workflow-level is preferred unless some jobs need additional permissions.

- File: `.github/workflows/ci.yml`
- Immediately after line 1 (`name: CI`), add:
  ```yaml
  permissions:
    contents: read
  ```
No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
